### PR TITLE
MAINT: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~


### PR DESCRIPTION
In GitLab by @tylerjereddy on Sep 14, 2020, 15:07

* add `.gitignore` with basic vim tags from:
https://github.com/github/gitignore/blob/master/Global/Vim.gitignore