### PR TITLE
TST: add property-based test for pyssg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+The unit tests depend on `pytest` and `hypothesis` libraries and can
+be run with the following after installing `py-ssg` and `py-margo`:
+
+`pytest test/`

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -19,15 +19,6 @@ def test_tcp_ssg_engine_names(group_name):
     # (hypothesis will try an empty string,
     # strange unicode strings, etc.)
 
-    # NOTE: at the moment the creation of multiple
-    # engine contexts from the same Python process
-    # does not appear to be tolerated?
-    
-    # We'll need to
-    # make sure each test case/example is launched from
-    # its own (sub)process somehow, but so far pytest-subtests
-    # is not up to the task when combined with hypothesis case
-    # generation
     with Engine('ofi+tcp', pymargo.core.server) as engine:
         g = pyssg.groups.create(group_name, engine, config=Config(),
                             addresses=[ str(engine.addr()) ],

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -1,0 +1,43 @@
+import sys
+from pymargo.core import Engine
+import pymargo.core
+import pyssg
+from pyssg.groups import Config, Member, Group
+from callback import MyMembershipCallback
+
+import pytest
+import hypothesis
+from hypothesis import given
+from hypothesis import strategies as st
+
+# use hypothesis to generate a wide range
+# of string values for testing
+@given(st.text())
+def test_tcp_ssg_engine_names(group_name):
+    # stress test the SSG group creation API
+    # on values of the group name string
+    # (hypothesis will try an empty string,
+    # strange unicode strings, etc.)
+
+    # NOTE: at the moment the creation of multiple
+    # engine contexts from the same Python process
+    # does not appear to be tolerated?
+    
+    # We'll need to
+    # make sure each test case/example is launched from
+    # its own (sub)process somehow, but so far pytest-subtests
+    # is not up to the task when combined with hypothesis case
+    # generation
+    with Engine('ofi+tcp', pymargo.core.server) as engine:
+        g = pyssg.groups.create(group_name, engine, config=Config(),
+                            addresses=[ str(engine.addr()) ],
+                            callback=MyMembershipCallback())
+
+        # check a few basic properties of this ssg group
+        assert g.size == 1
+        assert g.rank == 0
+        assert isinstance(g._Group__group_id, int)
+
+        g.leave()
+        engine.finalize()
+        pyssg.finalize()

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -40,4 +40,3 @@ def test_tcp_ssg_engine_names(group_name):
 
         g.leave()
         engine.finalize()
-        pyssg.finalize()

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -39,4 +39,3 @@ def test_tcp_ssg_engine_names(group_name):
         assert isinstance(g._Group__group_id, int)
 
         g.leave()
-        engine.finalize()


### PR DESCRIPTION
In GitLab by @tylerjereddy on Sep 24, 2020, 19:14

@mdorier @carns @gshipman @nawtrey 

* this drafts a first property-based `hypothesis` test
for `py-ssg`, focused on testing the string used for the
group name when creating groups with ssg

* the good news is that I've found no evidence that strange
strings cause issues

* the bad news is that py-ssg/py-margo engine/group creation
contexts appear to have a global state that prevents launching
many of them from the same Python process? This is a problem for
this kind of `hypothesis` case testing. While we can do parametrized
tests with `pytest --fork` to separate the processes, this does not
work with `hypothesis` case generation, nor does the use of the
`pytest-subtests` appoach; open to suggestions here.. currently
when more than one test case runs in the same process we get the error
below (only the first case passes):

```
engine = <pymargo.core.Engine object at 0x2b4edb261390>, group_name = '', config = <pyssg.groups.Config object at 0x2b4edb2611d0>, addresses = ['ofi+tcp;ofi_rxm://192.168.100.178:46366'], callback = <callback.MyMembershipCallback object at 0x2b4edb261310>

    def __create_simple(engine, group_name, config, addresses, callback):
>       ssgid = _pyssg.group_create(engine.get_internal_mid(), group_name, addresses, vars(config), callback)
E       RuntimeError: ssg_group_create_mpi failed
```

* added brief documentation on running the tests